### PR TITLE
Fix, dlna ssl cast to yamaha receivers fails if a 'Content-Length hea…

### DIFF
--- a/src/github/daneren2005/serverproxy/WebProxy.java
+++ b/src/github/daneren2005/serverproxy/WebProxy.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 public class WebProxy extends ServerProxy {
 	private static String TAG = WebProxy.class.getSimpleName();
-	private static List REMOVE_REQUEST_HEADERS = Arrays.asList("Host", "Accept-Encoding", "Referer");
+	private static List REMOVE_REQUEST_HEADERS = Arrays.asList("Host", "Accept-Encoding", "Referer", "Content-Length");
 	private static List REMOVE_RESPONSE_HEADERS = Arrays.asList("Transfer-Encoding");
 	private HttpClient httpClient;
 


### PR DESCRIPTION
…der already present exception' is thrown (with Content-Length = 0)
